### PR TITLE
Fix/ 로그인 시 성공 알림창 배경 이미지 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,19 +4,23 @@
 :root{
   background-color: #F5F5F5;
 }
+
 .container{
- /* display: flex; */
-  position: relative;
+
   width: 100%;
+  height: 100vh;
+
   display: flex;
+  flex-direction: column;
   height: auto;
-  justify-content: space-between;
+  justify-content: center;
+  align-items: center;
   background-color: #F5F5F5;
+
   container > *{
     min-width: 0;
     flex-shrink: 1;
   }
-  /* height: 100vh; */
   /* overflow: hidden; */
 }
 .leftcontainer{
@@ -43,10 +47,13 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh; 
-  margin-left: 220px;
-  margin-right: 220px;
   width: calc(100% - 440px);
   background-color: #f5f5f5;
+  height: 100%;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
 }
 
 .mainWrapper.fullWidth {
@@ -84,5 +91,4 @@
     justify-content: center;
   }
 }
-
 

--- a/src/pages/Mainpage/Footer.module.css
+++ b/src/pages/Mainpage/Footer.module.css
@@ -1,17 +1,14 @@
 
 
 .footer{
-    margin-top: 80px;
+    margin-top: auto;
     background-color: #F5F5F5;
-    padding:30px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+
     opacity: 0.6;
     border-top: 1px solid rgba(0,0,0,0.3);
     font-size:16px;
-    flex-wrap: wrap;
-    text-align: center;
+    padding-top: 1rem;
+    margin-bottom: 3rem;
     
 }
 

--- a/src/pages/Mainpage/Footer.module.css
+++ b/src/pages/Mainpage/Footer.module.css
@@ -1,7 +1,7 @@
 
 
 .footer{
-    /* margin-top: 80px; */
+    margin-top: 80px;
     background-color: #F5F5F5;
     padding:30px;
     display: flex;

--- a/src/style/sweetAlert.css
+++ b/src/style/sweetAlert.css
@@ -17,7 +17,7 @@
       rgba(255,255,255,0.85) 50%, 
       #ffffff 50%, 
       #ffffff 100%),
-    url('images/successImg2.jpg');
+    url('/images/successImg2.jpg');
   background-repeat: no-repeat;
   background-size: 100% auto;
   background-position: top;

--- a/src/utils/sweetAlert.tsx
+++ b/src/utils/sweetAlert.tsx
@@ -16,6 +16,10 @@ export const showSuccessAlert = (title:string, text?:string) => {
             confirmButton: 'my-confirm-button',
             icon: 'custom-icon-background',
         },
+        willOpen: ()=>{
+            const img = new Image();
+            img.src = '/images/successImg2.jpg';
+        }
     });
 };
 


### PR DESCRIPTION
## ✅작업 개요
로그인 성공 시 sweetalert창 뜰 때 배경 이미지 

## ⭐ 작업 내용
- [x] sweetalert 로그인 성공 시 배경 이미지 보이기

## 😥 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->

## 테스트 결과 보고
배경이미지가 랜덤으로 보이던 오류 수정