### PR TITLE
fix/ 마이페이지 디폴트 이름 띄우기 + 마이페이지 수정칸에서 다른사람 페이지가면 수정칸보이는것

### DIFF
--- a/src/pages/Mypage/MypageName.tsx
+++ b/src/pages/Mypage/MypageName.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ChangeEvent } from 'react';
+import { useEffect, useState, type ChangeEvent, type MutableRefObject } from 'react';
 import type { User } from './Mypage';
 import S from './MypageTop.module.css';
 import E from './MypageEdit.module.css';
@@ -12,13 +12,17 @@ interface Props {
     user: User | null;
     editMode: boolean;
     setUserData: React.Dispatch<React.SetStateAction<User | null>>;
+    canExitEditModeRef?: MutableRefObject<() => boolean>;
 }
 
-function MypageName({ user, editMode, setUserData}: Props) {
+function MypageName({ user, editMode, setUserData, canExitEditModeRef}: Props) {
 
   const { error } = useToast();
 
-  const [userName, setUserName] = useState<string>('');
+  const [userName, setUserName] = useState({
+    current: '', // 지금
+    original: '' // 처음
+  });
   const [role, setRole] = useState<string>('');
   const [showEdit, setShowEdit] = useState(false);
   const navigate = useNavigate();
@@ -26,8 +30,9 @@ function MypageName({ user, editMode, setUserData}: Props) {
 
   useEffect(() => {
       if( !editMode ) {
-        setShowEdit(false);
+          setShowEdit(false);
       }
+
   }, [editMode]);
 
   useEffect(() => {
@@ -48,8 +53,16 @@ function MypageName({ user, editMode, setUserData}: Props) {
         .single();
 
       if (userData) {
-         setUserName(userData.nickname);
-         setRole(userData.role);
+        const nickname = (userData.nickname ?? '').trim();
+        const original = nickname || '';
+
+        const role = (userData.role ?? '').trim();
+
+        setUserName({
+          current: nickname || '',
+          original: original
+        });
+        setRole(role || '프론트엔드');
       }
 
   };
@@ -58,19 +71,32 @@ function MypageName({ user, editMode, setUserData}: Props) {
 
   }, [profileId]);
 
+  useEffect(() => {
+    if (canExitEditModeRef) {
+      canExitEditModeRef.current = () => {
+        const trimmedCurrent = userName.current.trim();
+        const trimmedOriginal = userName.original.trim();
+        return !!(trimmedCurrent || trimmedOriginal); // 둘 다 없으면 false
+      };
+    }
+  }, [userName]);
+
     const handleEditName = () => {
       setShowEdit(true);
     }
 
     const handleSaveBtn = async () => {
+      const trimmedCurrent = userName.current.trim();
+      const trimmedOriginal = userName.original.trim();
+      const nameToSave = trimmedCurrent || trimmedOriginal;
 
-      if( typeof userName !== 'string' || !userName?.trim() ) {
-        error('이름 입력을 다시해주세요.')
+      if (!nameToSave) {
+        error('이름을 입력해주세요.');
         return;
       }
 
-      if( userName.length > 5 ) {
-        error('5글자 이하로 적어주세요.')
+      if (nameToSave.length > 5) {
+        error('5글자 이하로 적어주세요.');
         return;
       }
 
@@ -79,13 +105,13 @@ function MypageName({ user, editMode, setUserData}: Props) {
 
       const { error: nameError } = await supabase
         .from('user_base')
-        .update({nickname: userName})
+        .update({nickname: nameToSave})
         .eq('id', id);
 
       if( nameError ) {
           error('업데이트 실패')
           return;
-      }
+      } 
 
       const { error: roleError } = await supabase
         .from('user_base')
@@ -97,28 +123,31 @@ function MypageName({ user, editMode, setUserData}: Props) {
         return;
       }
 
-      if( typeof userName !== 'string' ) return;
-      if( typeof role !== 'string' ) return;
+      setUserName({
+        current: nameToSave,
+        original: nameToSave
+      })
 
       setUserData((prev) => {
             if( !prev ) return prev
 
             return {
                 ...prev,
-                nickname: userName,
+                nickname: nameToSave,
                 role: role
             }
         })
       
-      toast.info('성공적으로 저장되었습니다.', { onClose() {
-          navigate(`/mypage/${user?.profile[0]?.profile_id}`)
-        }, autoClose: 1500})
+      toast.info('성공적으로 저장되었습니다.', { autoClose: 1500});
       setShowEdit(false);
     }
 
     const handleInputChange = ( e:ChangeEvent<HTMLInputElement> ) => {
-      const name = e.currentTarget.value.trim();
-      setUserName( name );
+      const name = e.currentTarget.value;
+      setUserName((prev) => ({
+        ...prev,
+        current: name
+      }));
     }
 
     const handleSelectChange = ( e:ChangeEvent<HTMLSelectElement> ) => {
@@ -127,9 +156,27 @@ function MypageName({ user, editMode, setUserData}: Props) {
 
     const handleCancelBtn = () => {
       const result = confirm('변경하지 않고 나가시겠습니까?');
-      if( result ) {
-        setShowEdit(false);
+      if( !result ) return;
+
+      const safeName = userName.current.trim() || userName.original.trim();
+
+      if (!safeName) {
+        toast.error('이름이 없습니다.');
+        return;
       }
+
+      setUserName((prev) => ({
+        ...prev,
+        current: prev.original, // 취소 시 원래값으로 복원
+      }));
+      setShowEdit(false);
+    }
+
+    const handleEmptyValue = () => {
+      setUserName((prev) => ({
+        ...prev,
+        current: '',
+      }));
     }
 
 
@@ -138,7 +185,7 @@ function MypageName({ user, editMode, setUserData}: Props) {
       { editMode && 
         showEdit ? 
           <div className={E.editNamecontainer}>
-            <input type='text' placeholder={userName}  onChange={handleInputChange} />
+            <input type='text' value={userName.current} placeholder={userName.original || '프둥이'}  onChange={handleInputChange} onClick={handleEmptyValue} />
             <select onChange={handleSelectChange} defaultValue={role}>
               <option value="">분야를 선택해주세요.</option>
               <option value="프론트엔드">프론트엔드</option>
@@ -151,7 +198,7 @@ function MypageName({ user, editMode, setUserData}: Props) {
         : (
         <div className={S.mypageNameRole}>
           <span className={S.mypageName}>
-            {userName}
+            {userName.original || '프둥이'}
           </span>
           <span className={S.mypageRole}>
             {role}

--- a/src/pages/Mypage/MypageName.tsx
+++ b/src/pages/Mypage/MypageName.tsx
@@ -5,7 +5,7 @@ import E from './MypageEdit.module.css';
 import supabase from '../../supabase/supabase';
 import { useToast } from '@/utils/useToast';
 import { toast } from 'react-toastify';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 
 interface Props {
@@ -25,7 +25,6 @@ function MypageName({ user, editMode, setUserData, canExitEditModeRef}: Props) {
   });
   const [role, setRole] = useState<string>('');
   const [showEdit, setShowEdit] = useState(false);
-  const navigate = useNavigate();
   const { id: profileId } = useParams<{id: string}>();
 
   useEffect(() => {


### PR DESCRIPTION
## ✅작업 개요
<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
1. 처음 사용자의 마이페이지 디폴트 값은 ( 프둥이, 프론트엔드 )
2. 사용자가 처음 닉네임이 없는 상태에서 수정을 들어가서, 이름 입력값 없이 수정을 나가려고 할 때 리턴
3. 닉네임 입력값이 생기고 나서는 저장하지 않고 나갈시, 이전값으로 세팅
4. 수정 중일 때 다른 사용자의 마이페이지를 가면 수정칸이 보이는 버그 해결


## ⭐ 작업 내용
<!-- 어떤 작업을 하였는지 체크박스 형식으로 적어주세요 -->

## 😥 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->

## 테스트 결과 보고
<!-- 테스트 결과나 내용 기입 -->