### PR TITLE
fix/ 좌측 사이드바 팝업 레이아웃 다른 이름에 깔리는 현상 해결

### DIFF
--- a/src/components/UserList.module.css
+++ b/src/components/UserList.module.css
@@ -12,6 +12,7 @@
     left: 3rem;
     border-radius: 15px;
     padding: 1rem;
+    z-index: 10;
 
     ul {
         display: flex;


### PR DESCRIPTION
## ✅작업 개요
<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
팝업이 다른 이름 아래로 깔려서 zindex 줬습니다

## ⭐ 작업 내용
<!-- 어떤 작업을 하였는지 체크박스 형식으로 적어주세요 -->

## 😥 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->

## 테스트 결과 보고
<!-- 테스트 결과나 내용 기입 -->