### PR TITLE
style/해시태그 컬러수정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,6 +74,8 @@
   z-index: 99;
   pointer-events: auto;
 }
+
+
 @media screen and (max-width: 1024px) {
   .leftcontainer,
   .rightcontainer {

--- a/src/components/HashTag.module.css
+++ b/src/components/HashTag.module.css
@@ -3,17 +3,22 @@
 
 .hashTag {
   border: none;
-  --tag-bg: #a6b37d;
+  --tag-bg: #e2e8f0;
   --readonly-striped: 0;
   --tag--max-width: 300px;
   --tag-border-radius: 8px;
   span {
     font-size: 12px;
-    color: #fff;
+    color: #1e293b;
   }
 }
+
 .hashTagInput {
   width: 90%;
-  --tag-bg: #a6b37d;
-  --tag--max-width: 360px;
+  --tag-bg: #e2e8f0;
+  --tag--max-width: 300px;
+  span{
+    font-size: 12px;
+    color: #1e293b;
+  }
 }

--- a/src/components/HashTag.tsx
+++ b/src/components/HashTag.tsx
@@ -13,6 +13,7 @@ interface Props {
 interface BaseTagData {
   value: string;
 }
+
 function HashTag({ taglist, defaultList, editable, callBack }: Props) {
   const hasgTag = useRef(null);
   const onChange = useCallback(

--- a/src/components/Layout/Notification.tsx
+++ b/src/components/Layout/Notification.tsx
@@ -19,7 +19,7 @@ function Notification() {
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>, target: string|null) => {
     if (!target) return;
-    if (e.currentTarget.closest('button')) return
+    if ((e.target as HTMLElement).closest('button')) return
     navigate(`/channel/${target}`)
   }
   return (

--- a/src/components/Layout/card.module.css
+++ b/src/components/Layout/card.module.css
@@ -81,15 +81,3 @@
   width: 15px;
   height: 18px;
 }
-
-.tagStyle {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  height: 24px;
-  width: 48px;
-  font-size: 12px;
-  background-color: dodgerblue;
-  color: #fff;
-  border-radius: 4px;
-}

--- a/src/pages/BoardForm/BoardForm.tsx
+++ b/src/pages/BoardForm/BoardForm.tsx
@@ -11,7 +11,6 @@ import { useToast } from "@/utils/useToast";
 import { useHashTagContext } from "@/components/context/useHashTag";
 
 import { useProfileImageContext } from "@/components/context/useProfileImage";
-import { toast } from "react-toastify";
 import { useNavigate } from "react-router-dom";
 import { showConfirmAlert } from "@/utils/sweetAlert";
 
@@ -91,12 +90,9 @@ function BoardForm({ userId }: Props) {
       insertApproveMember(data[0].board_id);
       imageUpload(data[0].board_id);
       deleteSaveData();
-      toast.success("글이 게시되었습니다.", {
-        onClose() {
-          navigate("/study");
-        },
-        autoClose: 1500,
-      });
+      success("글이 게시되었습니다.");
+      navigate("/study");
+
     }
   };
 

--- a/src/supabase/database.types.ts
+++ b/src/supabase/database.types.ts
@@ -369,13 +369,6 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "notification_board_id_fkey"
-            columns: ["board_id"]
-            isOneToOne: false
-            referencedRelation: "board"
-            referencedColumns: ["board_id"]
-          },
-          {
             foreignKeyName: "notification_user_profile_id_fkey"
             columns: ["user_profile_id"]
             isOneToOne: false


### PR DESCRIPTION
## ✅작업 개요
해시태그 컬러수정및 소소한 기능도 추가했습니다

## ⭐ 작업 내용
[]카드 Ui와 글쓰기 폼에 나오는 해시태그 색을 변경하였습니다
[] 알림창에서 새로운 알림클릭시 알림이 발생한 글로 이동합니다
[] 글쓰기가 두번되는 버그를 고쳤습니다

## 😥 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->

## 테스트 결과 보고
로컬환경테스트를 마쳤습니다